### PR TITLE
Filter and order

### DIFF
--- a/env example
+++ b/env example
@@ -1,0 +1,3 @@
+DB_USER=postgres
+DB_PASSWORD=1234pass
+DB_HOST=localhost

--- a/src/controllers/category/createAndAddCategory.js
+++ b/src/controllers/category/createAndAddCategory.js
@@ -5,27 +5,13 @@ const createAndAddCategories = async (categories, product) => {
     const parsedCategories = categories.map((c) => {
       return { name: c };
     });
-    for (const category of parsedCategories) {
-      //--------Asi debería ser pero no funciona--------
-      //   const newCategory = await Category.findOrCreate({
-      //     where: {
-      //       name: category.name,
-      //     },
-      //   });
-      //   product.addCategories(newCategory);
-
-      //-------Parche temporal. Esto funciona aunque deja algunas categorías repetidas--------
-      const checkCategory = await Category.findOne({
+    for await (const category of parsedCategories) {
+      const [newCategory, created] = await Category.findOrCreate({
         where: {
           name: category.name,
         },
       });
-      if (checkCategory) {
-        product.addCategories(checkCategory);
-      } else {
-        const newCategory = await Category.create(category);
-        product.addCategories(newCategory);
-      }
+      product.addCategories(newCategory);
     }
   } catch (err) {
     console.log(err);

--- a/src/controllers/products/createProduct.js
+++ b/src/controllers/products/createProduct.js
@@ -12,8 +12,8 @@ const createProduct = async (data) => {
     stock,
     description,
   });
-  createAndAddImages(images, newProduct);
-  createAndAddCategories(categories, newProduct);
+  await createAndAddImages(images, newProduct);
+  await createAndAddCategories(categories, newProduct);
 };
 
 module.exports = createProduct;

--- a/src/controllers/products/getProducts.js
+++ b/src/controllers/products/getProducts.js
@@ -1,17 +1,9 @@
-const res = require("express/lib/response");
 const { Product, Image, Category } = require("../../database.js");
 
-const getProducts = async () => {
+const getProducts = async (whereStatement, categoryWhereStatement) => {
   try {
     const products = await Product.findAll({
-      attributes: [
-        "name",
-        "id",
-        "price",
-        "shippingCost",
-        "stock",
-        "description",
-      ],
+      ...whereStatement,
       include: [
         {
           model: Image,
@@ -21,19 +13,15 @@ const getProducts = async () => {
         {
           model: Category,
           as: "categories",
-          attributes: ["name"],
+          attributes: ["name", "id"],
+          ...categoryWhereStatement,
           through: {
             attributes: [],
           },
         },
       ],
     });
-    const editableProducts = products.map((product) => product.toJSON());
-    const productsWithSimpleCategories = editableProducts.map((product) => {
-      const categoryName = product.categories.map((category) => category.name);
-      return { ...product, categories: categoryName };
-    });
-    return productsWithSimpleCategories;
+    return products;
   } catch (err) {
     console.log(err);
   }

--- a/src/controllers/products/getProducts.js
+++ b/src/controllers/products/getProducts.js
@@ -1,9 +1,14 @@
 const { Product, Image, Category } = require("../../database.js");
 
-const getProducts = async (whereStatement, categoryWhereStatement) => {
+const getProducts = async (
+  orderDisposition,
+  whereStatement,
+  categoryWhereStatement
+) => {
   try {
     const products = await Product.findAll({
       ...whereStatement,
+      ...orderDisposition,
       include: [
         {
           model: Image,

--- a/src/controllers/products/utils/categoriesToStrings.js
+++ b/src/controllers/products/utils/categoriesToStrings.js
@@ -1,0 +1,10 @@
+const categoriesToStrings = async (products) => {
+  const editableProducts = products.map((product) => product.toJSON());
+  const productsWithSimpleCategories = editableProducts.map((product) => {
+    const categoryName = product.categories.map((category) => category.name);
+    return { ...product, categories: categoryName };
+  });
+  return productsWithSimpleCategories;
+};
+
+module.exports = categoriesToStrings;

--- a/src/controllers/products/utils/filterCompose.js
+++ b/src/controllers/products/utils/filterCompose.js
@@ -1,0 +1,33 @@
+const Sequelize = require("sequelize");
+
+const Op = Sequelize.Op;
+
+const filterCompose = async (
+  search, //search = "microsoft"
+  minPrice, //minPrice = 10
+  maxPrice, //maxPrice = 100
+  freeShipping, //freeShipping = true/false
+  categoryId //categoryId = 6
+) => {
+  var whereStatement = { where: {} };
+  if (search) {
+    whereStatement.where.name = { [Op.iLike]: `%${search}%` };
+  }
+  if (minPrice || maxPrice) {
+    min = minPrice ? minPrice : 0;
+    max = maxPrice ? maxPrice : Infinity;
+
+    whereStatement.where.price = { [Op.between]: [min, max] };
+  }
+  if (freeShipping) {
+    whereStatement.where.shippingCost = 0;
+  }
+  var categoryWhereStatement = { where: {} };
+  if (categoryId) {
+    categoryWhereStatement.where.id = categoryId;
+  }
+
+  return [whereStatement, categoryWhereStatement];
+};
+
+module.exports = filterCompose;

--- a/src/controllers/products/utils/orderCompose.js
+++ b/src/controllers/products/utils/orderCompose.js
@@ -1,0 +1,14 @@
+const Sequelize = require("sequelize");
+
+const Op = Sequelize.Op;
+
+const orderCompose = async (direction) => {
+  var orderStatement = { order: [] };
+  if (direction) {
+    orderStatement.order = [["price", direction]];
+  }
+
+  return orderStatement;
+};
+
+module.exports = orderCompose;

--- a/src/models/category.js
+++ b/src/models/category.js
@@ -9,16 +9,16 @@ module.exports = (sequelize) => {
         type: DataTypes.STRING,
         allowNull: false,
       },
+    },
+    {
+      //creo index en las opciones del modelo para poner propiedad unique
+      //asi luego al crear nunca se repiten
+      indexes: [
+        {
+          unique: true,
+          fields: ["name"],
+        },
+      ],
     }
-    // {
-    //   //creo index en las opciones del modelo para poner propiedad unique
-    //   //asi luego al crear nunca se repiten
-    //   indexes: [
-    //     {
-    //       unique: true,
-    //       fields: ["name"],
-    //     },
-    //   ],
-    // }
   );
 };

--- a/src/routes/products.js
+++ b/src/routes/products.js
@@ -1,17 +1,20 @@
 const router = require("express").Router();
-const { Product } = require("../database.js");
 const getProducts = require("../controllers/products/getProducts.js");
+const filterCompose = require("../controllers/products/utils/filterCompose.js");
 
 router.get("", async function (req, res) {
-  const { search } = req.query;
-  if (search) {
-    const allProducts = await getProducts();
-    const searchedProduct = allProducts.filter((product) => {
-      return product.name.toLowerCase().includes(search.toLowerCase());
-    });
-    return res.status(200).send(searchedProduct);
+  const { search, minPrice, maxPrice, freeShipping, categoryId } = req.query;
+  var filterConditions = [undefined, undefined];
+  if (search || minPrice || maxPrice || freeShipping || categoryId) {
+    filterConditions = await filterCompose(
+      search,
+      minPrice,
+      maxPrice,
+      freeShipping,
+      categoryId
+    );
   }
-  const products = await getProducts();
+  const products = await getProducts(...filterConditions);
   return res.status(200).send(products);
 });
 

--- a/src/routes/products.js
+++ b/src/routes/products.js
@@ -1,10 +1,12 @@
 const router = require("express").Router();
 const getProducts = require("../controllers/products/getProducts.js");
 const filterCompose = require("../controllers/products/utils/filterCompose.js");
+const orderCompose = require("../controllers/products/utils/orderCompose.js");
 
 router.get("", async function (req, res) {
-  const { search, minPrice, maxPrice, freeShipping, categoryId } = req.query;
-  var filterConditions = [undefined, undefined];
+  const { search, minPrice, maxPrice, freeShipping, categoryId, order } =
+    req.query;
+  var filterConditions = [];
   if (search || minPrice || maxPrice || freeShipping || categoryId) {
     filterConditions = await filterCompose(
       search,
@@ -14,7 +16,10 @@ router.get("", async function (req, res) {
       categoryId
     );
   }
-  const products = await getProducts(...filterConditions);
+  if (order) {
+    var orderDisposition = await orderCompose(order);
+  }
+  const products = await getProducts(orderDisposition, ...filterConditions);
   return res.status(200).send(products);
 });
 


### PR DESCRIPTION
Refactor de ruta de get agregando funcionalidades.
Los posibles queries de búsqueda son: 
search (string para buscar por nombre)
minPrice (número para filtrar por precio mínimo de productos)
maxPrice(número para filtrar por precio máximo de productos) - Puede buscarse por uno solo, ambos o ninguno.
freeShipping(booleano, true o false para buscar por envío gratis)
categoryId(número, para buscar solo de esa categoría) <--- Tiene bug. Trae todos los productos de esa categoría pero pierden las demás categorías de su propiedad. No debería causar problemas para el funcionamiento del front, pero más adelante intento arreglarlo.
order(solo acepta ASC y DESC, ordena por precio ascendiente o descendiente)

ejemplo:
http://localhost:3001/products?search=microsoft&minPrice=100&maxPrice=600 traería los productos con microsoft en su nombre, que tengan precio entre 100 y 600.

Extra: 
¡arreglado el bug previo de categorías que se repetían!
archivo de ejemplo de .env