### PR TITLE
Pagination

### DIFF
--- a/src/controllers/products/createProduct.js
+++ b/src/controllers/products/createProduct.js
@@ -3,9 +3,18 @@ const createAndAddImages = require("../images/createAndAddImages.js");
 const createAndAddCategories = require("../category/createAndAddCategory.js");
 
 const createProduct = async (data) => {
-  const { name, price, shippingCost, stock, description, images, categories } =
-    data;
+  const {
+    title,
+    name,
+    price,
+    shippingCost,
+    stock,
+    description,
+    images,
+    categories,
+  } = data;
   const newProduct = await Product.create({
+    title,
     name,
     price,
     shippingCost,

--- a/src/controllers/products/getProducts.js
+++ b/src/controllers/products/getProducts.js
@@ -2,6 +2,7 @@ const { Product, Image, Category } = require("../../database.js");
 
 const getProducts = async (
   orderDisposition,
+  paginationSettings,
   whereStatement,
   categoryWhereStatement
 ) => {
@@ -9,6 +10,7 @@ const getProducts = async (
     const products = await Product.findAll({
       ...whereStatement,
       ...orderDisposition,
+      ...paginationSettings,
       include: [
         {
           model: Image,

--- a/src/controllers/products/utils/countPages.js
+++ b/src/controllers/products/utils/countPages.js
@@ -1,0 +1,14 @@
+const Sequelize = require("sequelize");
+const { Product } = require("../../../database.js");
+
+const Op = Sequelize.Op;
+
+const countPages = async (itemsPerPage) => {
+  const amountOfProducts = await Product.count({
+    where: { stock: { [Op.gt]: 0 } },
+  });
+
+  return Math.ceil(amountOfProducts / itemsPerPage ? itemsPerPage : 16);
+};
+
+module.exports = countPages;

--- a/src/controllers/products/utils/filterCompose.js
+++ b/src/controllers/products/utils/filterCompose.js
@@ -9,7 +9,7 @@ const filterCompose = async (
   freeShipping, //freeShipping = true/false
   categoryId //categoryId = 6
 ) => {
-  var whereStatement = { where: {} };
+  var whereStatement = { where: { stock: { [Op.gt]: 0 } } }; // default - only show those with at least 1 available stock
   if (search) {
     whereStatement.where.name = { [Op.iLike]: `%${search}%` };
   }

--- a/src/controllers/products/utils/orderCompose.js
+++ b/src/controllers/products/utils/orderCompose.js
@@ -3,7 +3,7 @@ const Sequelize = require("sequelize");
 const Op = Sequelize.Op;
 
 const orderCompose = async (direction) => {
-  var orderStatement = { order: [] };
+  var orderStatement = { order: [["id", "ASC"]] };
   if (direction) {
     orderStatement.order = [["price", direction]];
   }

--- a/src/controllers/products/utils/paginationCompose.js
+++ b/src/controllers/products/utils/paginationCompose.js
@@ -1,0 +1,19 @@
+const Sequelize = require("sequelize");
+
+const Op = Sequelize.Op;
+
+const paginationCompose = async (page, itemsPerPage) => {
+  if (!itemsPerPage) {
+    itemsPerPage = 16; //default
+  }
+  if (!page) {
+    page = 1;
+  }
+  var orderStatement = {
+    offset: (page - 1) * itemsPerPage,
+    limit: itemsPerPage,
+  };
+  return orderStatement;
+};
+
+module.exports = paginationCompose;

--- a/src/controllers/products/utils/paginationCompose.js
+++ b/src/controllers/products/utils/paginationCompose.js
@@ -4,10 +4,10 @@ const Op = Sequelize.Op;
 
 const paginationCompose = async (page, itemsPerPage) => {
   if (!itemsPerPage) {
-    itemsPerPage = 16; //default
+    itemsPerPage = 16; //default 16
   }
   if (!page) {
-    page = 1;
+    page = 1; //default 1
   }
   var orderStatement = {
     offset: (page - 1) * itemsPerPage,

--- a/src/models/product.js
+++ b/src/models/product.js
@@ -2,6 +2,10 @@ const { DataTypes } = require("sequelize");
 
 module.exports = (sequelize) => {
   sequelize.define("product", {
+    title: {
+      type: DataTypes.STRING,
+      allowNull: false,
+    },
     name: {
       type: DataTypes.STRING,
       allowNull: false,

--- a/src/routes/products.js
+++ b/src/routes/products.js
@@ -2,24 +2,34 @@ const router = require("express").Router();
 const getProducts = require("../controllers/products/getProducts.js");
 const filterCompose = require("../controllers/products/utils/filterCompose.js");
 const orderCompose = require("../controllers/products/utils/orderCompose.js");
+const paginationCompose = require("../controllers/products/utils/paginationCompose.js");
 
 router.get("", async function (req, res) {
-  const { search, minPrice, maxPrice, freeShipping, categoryId, order } =
-    req.query;
-  var filterConditions = [];
-  if (search || minPrice || maxPrice || freeShipping || categoryId) {
-    filterConditions = await filterCompose(
-      search,
-      minPrice,
-      maxPrice,
-      freeShipping,
-      categoryId
-    );
-  }
-  if (order) {
-    var orderDisposition = await orderCompose(order);
-  }
-  const products = await getProducts(orderDisposition, ...filterConditions);
+  const {
+    search,
+    minPrice,
+    maxPrice,
+    freeShipping,
+    categoryId,
+    order,
+    limit,
+    offset,
+  } = req.query;
+  const filterConditions = await filterCompose(
+    search,
+    minPrice,
+    maxPrice,
+    freeShipping,
+    categoryId
+  );
+  const orderDisposition = await orderCompose(order);
+  const paginationSettings = await paginationCompose(offset, limit);
+  const products = await getProducts(
+    orderDisposition,
+    paginationSettings,
+    ...filterConditions
+  );
+
   return res.status(200).send(products);
 });
 

--- a/src/routes/products.js
+++ b/src/routes/products.js
@@ -1,5 +1,6 @@
 const router = require("express").Router();
 const getProducts = require("../controllers/products/getProducts.js");
+const countPages = require("../controllers/products/utils/countPages.js");
 const filterCompose = require("../controllers/products/utils/filterCompose.js");
 const orderCompose = require("../controllers/products/utils/orderCompose.js");
 const paginationCompose = require("../controllers/products/utils/paginationCompose.js");
@@ -29,8 +30,14 @@ router.get("", async function (req, res) {
     paginationSettings,
     ...filterConditions
   );
-
-  return res.status(200).send(products);
+  const pages = await countPages(limit);
+  return res
+    .status(200)
+    .send({
+      products: products,
+      pages: pages,
+      page: offset ? Number(offset) : 1,
+    });
 });
 
 module.exports = router;


### PR DESCRIPTION
Paginado listo. Eso necesitó algunos cambios a lo hecho previamente.

Ahora la ruta de get de productos trae un objeto con este formato:
{ **products**: [ {...}, {...}, ... ], **pages**: 5, **page**: 1}

De forma que uno recibe en pages la cantidad total de páginas, en page la página donde esta parado y en products los productos de esa página.
La ruta para buscar por paginado trabaja con dos queries nuevas:
**limit** es la cantidad de productos por página
**offset** es la página que quiero que me traiga

Ejemplo: http://localhost:3001/products?limit=8&offset=2
me dividirá los productos por páginas de a 8 y me traerá la página 2.

Si no se da limit el default es 16, si no se da offset el default es 1.
Funciona en conjunto con todas las demás queries, por lo que uno puede pedir ciertos filtros y aun así vendrá paginado.

Extra:
Agregué las lineas necesarias para que también traiga el título del producto (nombre reducido que agregaron más temprano)